### PR TITLE
Added support for windows style new lines

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -25,7 +25,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     if proc.returncode != 0:
         raise IOError("OpenSSL Error: {0}".format(err))
     pub_hex, pub_exp = re.search(
-        r"modulus:\n\s+00:([a-f0-9\:\s]+?)\npublicExponent: ([0-9]+)",
+        r"modulus:[\r\n]+\s+00:([a-f0-9\:\s]+?)[\r\n]+publicExponent: ([0-9]+)",
         out.decode('utf8'), re.MULTILINE|re.DOTALL).groups()
     pub_exp = "{0:x}".format(int(pub_exp))
     pub_exp = "0{0}".format(pub_exp) if len(pub_exp) % 2 else pub_exp


### PR DESCRIPTION
In openssl 1.1.0 for windows the response uses windows style new lines (\r\n). This commit adds support for those.
